### PR TITLE
Rust 2021/analyser fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["raspberry", "pi", "rpi"]
 links = "mmal"
 build = "build.rs"
 exclude = [ "ci/*" ]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -112,13 +112,13 @@ fn locate_mmal_lib_dir() -> String {
     };
 
     if !Path::new(&path).exists() {
-        panic!(format!("Could not locate libary.
+        panic!("Could not locate libary.
 path: {}
 default: {}
 env MMAL_LIB_DIR: {:?}
 ",
             path, default_path, env::var("MMAL_LIB_DIR")
-        ));
+        );
     }
 
     path

--- a/build.rs
+++ b/build.rs
@@ -91,13 +91,13 @@ fn locate_mmal_headers() -> String {
     };
 
     if !Path::new(&path).exists() {
-        panic!(format!("Could not locate mmal headers.
+        panic!("Could not locate mmal headers.
 path: {}
 default: {}
 env MMAL_INCLUDE_DIR: {:?}
 ",
             path, default_path, env::var("MMAL_INCLUDE_DIR")
-	));
+	    );
     }
 
     path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ impl fmt::Display for MMAL_PARAMETER_CAMERA_INFO_CAMERA_T {
         write!(
             f,
             "{} {}x{}",
-            ::std::str::from_utf8(&self.camera_name).unwrap(),
+            unsafe { std::ffi::CStr::from_ptr(self.camera_name.as_ptr()).to_string_lossy().into_owned() },
             self.max_width,
             self.max_height
         )


### PR DESCRIPTION
Basic Rust 2021 compatibility.

In particular, this PR fixes the following error that appear under rust-analyzer:

```
error[E0308]: mismatched types
   --> /workspaces/src/mmal-sys/src/lib.rs:290:35
    |
290 |             ::std::str::from_utf8(&self.camera_name).unwrap(),
    |             --------------------- ^^^^^^^^^^^^^^^^^ expected slice `[u8]`, found array `[i8; 16]`
    |             |
    |             arguments to this function are incorrect
    |
    = note: expected reference `&[u8]`
               found reference `&[i8; 16]`
note: function defined here
   --> /usr/local/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/str/converts.rs:87:14
    |
87  | pub const fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
    |              ^^^^^^^^^


```